### PR TITLE
Remove export field, source code is located in the root of library

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,8 +17,5 @@
   },
   "version":"0.2.1",
   "frameworks": "arduino",
-  "platforms": "*",
-  "export": {
-    "include": "PrintSize"
-  }
+  "platforms": "*"
 }


### PR DESCRIPTION
@RobTillaart, do you plan to split other libraries (https://github.com/RobTillaart/Arduino.git) into own repository?